### PR TITLE
AQ20/Ossirian: Add scheduled event for Cyclone

### DIFF
--- a/Raids/AQ20/Ossirian.lua
+++ b/Raids/AQ20/Ossirian.lua
@@ -11,77 +11,77 @@ local module, L = BigWigs:ModuleDeclaration("Ossirian the Unscarred", "Ruins of 
 ----------------------------
 
 L:RegisterTranslations("enUS", function() return {
-	cmd = "Ossirian",
+  cmd = "Ossirian",
 
-	supreme_cmd = "supreme",
-	supreme_name = "Supreme Alert",
-	supreme_desc = "Warn for Supreme Mode",
+  supreme_cmd = "supreme",
+  supreme_name = "Supreme Alert",
+  supreme_desc = "Warn for Supreme Mode",
 
-	debuff_cmd = "debuff",
-	debuff_name = "Debuff Alert",
-	debuff_desc = "Warn for Defuff",
+  debuff_cmd = "debuff",
+  debuff_name = "Debuff Alert",
+  debuff_desc = "Warn for Defuff",
 
-	supremetrigger = "Ossirian the Unscarred gains Strength of Ossirian.",
-	supremewarn = "Ossirian Supreme Mode!",
-	supremedelaywarn = "Supreme in %d seconds!",
-	debufftrigger = "Ossirian the Unscarred is afflicted by (.+) Weakness.",
-	crystaltrigger = "Ossirian Crystal Trigger dies.",
-	debuffwarn = "Ossirian now weak to %s!",
-	supreme_bar = "Supreme",
-	expose = "Expose",
-	
-	["cyclone_trigger"] = "Enveloping Winds",
-	["stomp_trigger"] = "War Stomp",
-	
-	["WarStomp"] = "War Stomp",
-	["Cyclone"] = "Cyclone",
+  supremetrigger = "Ossirian the Unscarred gains Strength of Ossirian.",
+  supremewarn = "Ossirian Supreme Mode!",
+  supremedelaywarn = "Supreme in %d seconds!",
+  debufftrigger = "Ossirian the Unscarred is afflicted by (.+) Weakness.",
+  crystaltrigger = "Ossirian Crystal Trigger dies.",
+  debuffwarn = "Ossirian now weak to %s!",
+  supreme_bar = "Supreme",
+  expose = "Expose",
 
-	["Shadow"] = true,
-	["Fire"] = true,
-	["Frost"] = true,
-	["Nature"] = true,
-	["Arcane"] = true,
-	
-	["ShadowIcon"] = "Spell_Shadow_ChillTouch",
-	["FireIcon"] = "Spell_Fire_Fire",
-	["FrostIcon"] = "Spell_Frost_ChillingBlast",
-	["NatureIcon"] = "Spell_Nature_Acid_01",
-	["ArcaneIcon"] = "Spell_Arcane_PortalOrgrimmar",
+  ["cyclone_trigger"] = "Enveloping Winds",
+  ["stomp_trigger"] = "War Stomp",
+
+  ["WarStomp"] = "War Stomp",
+  ["Cyclone"] = "Cyclone",
+
+  ["Shadow"] = true,
+  ["Fire"] = true,
+  ["Frost"] = true,
+  ["Nature"] = true,
+  ["Arcane"] = true,
+
+  ["ShadowIcon"] = "Spell_Shadow_ChillTouch",
+  ["FireIcon"] = "Spell_Fire_Fire",
+  ["FrostIcon"] = "Spell_Frost_ChillingBlast",
+  ["NatureIcon"] = "Spell_Nature_Acid_01",
+  ["ArcaneIcon"] = "Spell_Arcane_PortalOrgrimmar",
 } end )
 
 L:RegisterTranslations("deDE", function() return {
-	supreme_name = "Stärke des Ossirian",
-	supreme_desc = "Warnung vor Stärke des Ossirian.",
+  supreme_name = "Stärke des Ossirian",
+  supreme_desc = "Warnung vor Stärke des Ossirian.",
 
-	debuff_name = "Debuff",
-	debuff_desc = "Warnung vor Debuff.",
+  debuff_name = "Debuff",
+  debuff_desc = "Warnung vor Debuff.",
 
-	supremetrigger = "Ossirian der Narbenlose bekommt 'Stärke des Ossirian'.",
-	supremewarn = "Stärke des Ossirian!",
-	supremedelaywarn = "Stärke des Ossirian in %d Sekunden!",
-	debufftrigger = "Ossirian der Narbenlose ist von (.*)schwäche betroffen.",
-	crystaltrigger = "Ossirian Crystal Trigger dies.", -- translation missing
-	debuffwarn = "Ossirian für 45 Sekunden anfällig gegen: %s",
-	supreme_bar = "Stärke des Ossirian",
-	expose = "Schwäche",
-	
-	["cyclone_trigger"] = "Enveloping Winds",
-	["stomp_trigger"] = "War Stomp",
-	
-	["WarStomp"] = "War Stomp",
-	["Cyclone"] = "Cyclone",
+  supremetrigger = "Ossirian der Narbenlose bekommt 'Stärke des Ossirian'.",
+  supremewarn = "Stärke des Ossirian!",
+  supremedelaywarn = "Stärke des Ossirian in %d Sekunden!",
+  debufftrigger = "Ossirian der Narbenlose ist von (.*)schwäche betroffen.",
+  crystaltrigger = "Ossirian Crystal Trigger dies.", -- translation missing
+  debuffwarn = "Ossirian für 45 Sekunden anfällig gegen: %s",
+  supreme_bar = "Stärke des Ossirian",
+  expose = "Schwäche",
 
-	["Shadow"] = "Schatten",
-	["Fire"] = "Feuer",
-	["Frost"] = "Frost",
-	["Nature"] = "Natur",
-	["Arcane"] = "Arkan",
-	
-	["ShadowIcon"] = "Spell_Shadow_ChillTouch",
-	["FireIcon"] = "Spell_Fire_Fire",
-	["FrostIcon"] = "Spell_Frost_ChillingBlast",
-	["NatureIcon"] = "Spell_Nature_Acid_01",
-	["ArcaneIcon"] = "Spell_Arcane_PortalOrgrimmar",
+  ["cyclone_trigger"] = "Enveloping Winds",
+  ["stomp_trigger"] = "War Stomp",
+
+  ["WarStomp"] = "War Stomp",
+  ["Cyclone"] = "Cyclone",
+
+  ["Shadow"] = "Schatten",
+  ["Fire"] = "Feuer",
+  ["Frost"] = "Frost",
+  ["Nature"] = "Natur",
+  ["Arcane"] = "Arkan",
+
+  ["ShadowIcon"] = "Spell_Shadow_ChillTouch",
+  ["FireIcon"] = "Spell_Fire_Fire",
+  ["FrostIcon"] = "Spell_Frost_ChillingBlast",
+  ["NatureIcon"] = "Spell_Nature_Acid_01",
+  ["ArcaneIcon"] = "Spell_Arcane_PortalOrgrimmar",
 } end )
 
 
@@ -97,23 +97,23 @@ module.toggleoptions = {"supreme", "debuff", "bosskill"}
 
 -- locals
 local timer = {
-	weakness = 45,
-	supreme = 45,
-	firstCyclone = 20,
-	cyclone = 15,
-	warstomp = 25,
+  weakness = 45,
+  supreme = 45,
+  firstCyclone = 20,
+  cyclone = 15,
+  warstomp = 25,
 }
 local icon = {
-	supreme = "Spell_Shadow_CurseOfTounges",
-	warstomp = "Ability_BullRush",
-	cyclone = "Spell_Nature_Cyclone",
+  supreme = "Spell_Shadow_CurseOfTounges",
+  warstomp = "Ability_BullRush",
+  cyclone = "Spell_Nature_Cyclone",
 }
 local syncName = {
-	weakness = "OssirianWeakness"..module.revision,
-	crystal = "OssirianCrystal"..module.revision,
-	supreme = "OssirianSupreme"..module.revision,
-	warstomp = "OssirianWarstomp"..module.revision,
-	cyclone = "OssirianCyclone"..module.revision,
+  weakness = "OssirianWeakness"..module.revision,
+  crystal = "OssirianCrystal"..module.revision,
+  supreme = "OssirianSupreme"..module.revision,
+  warstomp = "OssirianWarstomp"..module.revision,
+  cyclone = "OssirianCyclone"..module.revision,
 }
 
 local currentWeakness = nil
@@ -128,33 +128,33 @@ local timeLastWeaken = nil
 
 -- called after module is enabled
 function module:OnEnable()
-	self:RegisterEvent("CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS")
-	self:RegisterEvent("CHAT_MSG_SPELL_PERIODIC_CREATURE_DAMAGE")
-	
-	self:RegisterEvent("CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE", "Debuff")
-	self:RegisterEvent("CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE", "Debuff")
-	self:RegisterEvent("CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE", "Debuff")
-	self:RegisterEvent("CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE", "Debuff")
-	self:RegisterEvent("CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE", "Debuff")
-	self:RegisterEvent("CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE", "Debuff")
-	
-	self:ThrottleSync(3, syncName.weakness)
-	self:ThrottleSync(3, syncName.crystal)
-	self:ThrottleSync(3, syncName.supreme)
-	self:ThrottleSync(3, syncName.cyclone)
-	self:ThrottleSync(3, syncName.warstomp)
+  self:RegisterEvent("CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS")
+  self:RegisterEvent("CHAT_MSG_SPELL_PERIODIC_CREATURE_DAMAGE")
+
+  self:RegisterEvent("CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE", "Debuff")
+  self:RegisterEvent("CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE", "Debuff")
+  self:RegisterEvent("CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE", "Debuff")
+  self:RegisterEvent("CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE", "Debuff")
+  self:RegisterEvent("CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE", "Debuff")
+  self:RegisterEvent("CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE", "Debuff")
+
+  self:ThrottleSync(3, syncName.weakness)
+  self:ThrottleSync(3, syncName.crystal)
+  self:ThrottleSync(3, syncName.supreme)
+  self:ThrottleSync(3, syncName.cyclone)
+  self:ThrottleSync(3, syncName.warstomp)
 end
 
 -- called after module is enabled and after each wipe
 function module:OnSetup()
-	timeLastWeaken = GetTime()
-    self:RegisterEvent("CHAT_MSG_COMBAT_HOSTILE_DEATH")
+  timeLastWeaken = GetTime()
+  self:RegisterEvent("CHAT_MSG_COMBAT_HOSTILE_DEATH")
 end
 
 -- called after boss is engaged
 function module:OnEngage()
-	self:Bar(L["Cyclone"], timer.firstCyclone, icon.cyclone)
-	self:Bar(L["WarStomp"], timer.warstomp, icon.warstomp)
+  self:Bar(L["Cyclone"], timer.firstCyclone, icon.cyclone)
+  self:Bar(L["WarStomp"], timer.warstomp, icon.warstomp)
 end
 
 -- called after boss is disengaged (wipe(retreat) or victory)
@@ -167,26 +167,26 @@ end
 ------------------------------
 
 function module:CHAT_MSG_COMBAT_HOSTILE_DEATH(msg)
-	BigWigs:CheckForBossDeath(msg, self)
-	
-	-- if the same weakness triggers back to back, the normal combat log entry is missing for the weakness
-	-- this event is triggered 2s later
-	if string.find(msg, L["crystaltrigger"]) then
-		self:Sync(syncName.crystal)
-	end
+  BigWigs:CheckForBossDeath(msg, self)
+
+  -- if the same weakness triggers back to back, the normal combat log entry is missing for the weakness
+  -- this event is triggered 2s later
+  if string.find(msg, L["crystaltrigger"]) then
+    self:Sync(syncName.crystal)
+  end
 end
 
 function module:CHAT_MSG_SPELL_PERIODIC_CREATURE_DAMAGE( msg )
-	local _, _, debuffName = string.find(msg, L["debufftrigger"])
-	if debuffName and debuffName ~= L["expose"] and L:HasReverseTranslation(debuffName) then
-		self:Sync(syncName.weakness .. " " .. L:GetReverseTranslation(debuffName))
-	end
+  local _, _, debuffName = string.find(msg, L["debufftrigger"])
+  if debuffName and debuffName ~= L["expose"] and L:HasReverseTranslation(debuffName) then
+    self:Sync(syncName.weakness .. " " .. L:GetReverseTranslation(debuffName))
+  end
 end
 
 function module:CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS( msg )
-	if string.find(msg, L["supremetrigger"]) then
-		self:Sync(syncName.supreme)
-	end
+  if string.find(msg, L["supremetrigger"]) then
+    self:Sync(syncName.supreme)
+  end
 end
 
 
@@ -195,17 +195,17 @@ end
 ------------------------------
 
 function module:BigWigs_RecvSync(sync, rest, nick)
-	if sync == syncName.weakness and rest then
-		self:Weakness(rest)
-	elseif sync == syncName.crystal then
-		self:Crystal()
-	elseif sync == syncName.supreme then
-		self:Supreme()
-	elseif sync == syncName.cyclone then
-		self:Cyclone()
-	elseif sync == syncName.warstomp then
-		self:Bar(L["WarStomp"], timer.warstomp, icon.warstomp)
-	end
+  if sync == syncName.weakness and rest then
+    self:Weakness(rest)
+  elseif sync == syncName.crystal then
+    self:Crystal()
+  elseif sync == syncName.supreme then
+    self:Supreme()
+  elseif sync == syncName.cyclone then
+    self:Cyclone()
+  elseif sync == syncName.warstomp then
+    self:Bar(L["WarStomp"], timer.warstomp, icon.warstomp)
+  end
 end
 
 ------------------------------
@@ -219,51 +219,51 @@ function module:Cyclone()
 end
 
 function module:Weakness(weakness, delay)
-	if not weakness then
-        return
-    end
-    if not delay then
-		delay = 0
-	end
-	
-	timeLastWeaken = GetTime()
-	currentWeakness = weakness
+  if not weakness then
+    return
+  end
+  if not delay then
+    delay = 0
+  end
 
-	if self.db.profile.debuff then
-		self:Message(string.format(L["debuffwarn"], L[tostring(weakness)]), "Important")
-		self:Bar(L[weakness], timer.weakness - delay, L[weakness .. "Icon"])
-	end
+  timeLastWeaken = GetTime()
+  currentWeakness = weakness
 
-	self:RemoveBar(L["supreme_bar"])
-	self:CancelDelayedMessage(string.format(L["supremedelaywarn"], 15))
-	self:CancelDelayedMessage(string.format(L["supremedelaywarn"], 10))
-	self:CancelDelayedMessage(string.format(L["supremedelaywarn"], 5))
+  if self.db.profile.debuff then
+    self:Message(string.format(L["debuffwarn"], L[tostring(weakness)]), "Important")
+    self:Bar(L[weakness], timer.weakness - delay, L[weakness .. "Icon"])
+  end
 
-	if self.db.profile.supreme then
-		self:DelayedMessage(timer.supreme - delay, string.format(L["supremedelaywarn"], 15), "Attention", nil, nil, true)
-		self:DelayedMessage(timer.supreme - delay, string.format(L["supremedelaywarn"], 10), "Urgent", nil, nil, true)
-		self:DelayedMessage(timer.supreme - delay, string.format(L["supremedelaywarn"], 5), "Important", nil, nil, true)
-		self:Bar(L["supreme_bar"], timer.supreme - delay, icon.supreme)
-	end
+  self:RemoveBar(L["supreme_bar"])
+  self:CancelDelayedMessage(string.format(L["supremedelaywarn"], 15))
+  self:CancelDelayedMessage(string.format(L["supremedelaywarn"], 10))
+  self:CancelDelayedMessage(string.format(L["supremedelaywarn"], 5))
+
+  if self.db.profile.supreme then
+    self:DelayedMessage(timer.supreme - delay, string.format(L["supremedelaywarn"], 15), "Attention", nil, nil, true)
+    self:DelayedMessage(timer.supreme - delay, string.format(L["supremedelaywarn"], 10), "Urgent", nil, nil, true)
+    self:DelayedMessage(timer.supreme - delay, string.format(L["supremedelaywarn"], 5), "Important", nil, nil, true)
+    self:Bar(L["supreme_bar"], timer.supreme - delay, icon.supreme)
+  end
 end
 
 function module:Crystal()
-	if timeLastWeaken + 3 < GetTime() then -- crystal trigger occurs 2s after weaken trigger
-		self:Weakness(currentWeakness, 2)
-	end
+  if timeLastWeaken + 3 < GetTime() then -- crystal trigger occurs 2s after weaken trigger
+    self:Weakness(currentWeakness, 2)
+  end
 end
 
 function module:Supreme()
-	if self.db.profile.supreme then
-		self:Message(L["supremewarn"], "Attention", nil, "Beware")
-	end
+  if self.db.profile.supreme then
+    self:Message(L["supremewarn"], "Attention", nil, "Beware")
+  end
 end
 
 function module:Debuff(msg)
-	if string.find(msg, L["cyclone_trigger"])then
-		self:Sync(syncName.cyclone)
-	end
-	if string.find(msg, L["stomp_trigger"])then
-		self:Sync(syncName.warstomp)
-	end
+  if string.find(msg, L["cyclone_trigger"])then
+    self:Sync(syncName.cyclone)
+  end
+  if string.find(msg, L["stomp_trigger"])then
+    self:Sync(syncName.warstomp)
+  end
 end

--- a/Raids/AQ20/Ossirian.lua
+++ b/Raids/AQ20/Ossirian.lua
@@ -202,7 +202,7 @@ function module:BigWigs_RecvSync(sync, rest, nick)
 	elseif sync == syncName.supreme then
 		self:Supreme()
 	elseif sync == syncName.cyclone then
-		self:Bar(L["Cyclone"], timer.cyclone, icon.cyclone)
+		self:Cyclone()
 	elseif sync == syncName.warstomp then
 		self:Bar(L["WarStomp"], timer.warstomp, icon.warstomp)
 	end
@@ -211,6 +211,12 @@ end
 ------------------------------
 --      Sync Handlers	    --
 ------------------------------
+
+function module:Cyclone()
+  self:CancelScheduledEvent("bw_ossirian_cyclone_repeating")
+  self:Bar(L["Cyclone"], timer.cyclone, icon.cyclone)
+  self:ScheduleRepeatingEvent("bw_ossirian_cyclone_repeating", self.Cyclone, timer.cyclone, self)
+end
 
 function module:Weakness(weakness, delay)
 	if not weakness then

--- a/Raids/AQ20/Ossirian.lua
+++ b/Raids/AQ20/Ossirian.lua
@@ -213,9 +213,9 @@ end
 ------------------------------
 
 function module:Cyclone()
-  self:CancelScheduledEvent("bw_ossirian_cyclone_repeating")
+  self:CancelScheduledEvent("bw_ossirian_cyclone")
   self:Bar(L["Cyclone"], timer.cyclone, icon.cyclone)
-  self:ScheduleRepeatingEvent("bw_ossirian_cyclone_repeating", self.Cyclone, timer.cyclone, self)
+  self:ScheduleEvent("bw_ossirian_cyclone", self.Cyclone, timer.cyclone, self)
 end
 
 function module:Weakness(weakness, delay)


### PR DESCRIPTION
this enables BigWigs to show a timer even for every fourth Cyclone.
Normally, no timer is shown after every 4th Cyclone because the tank is
not affected by the Cyclone at all due to diminishing return mechanics.
This DR-immune does not produce an event, thus the timer. Accuracy is not
negatively impacted, because Bar and Timer are refreshed on every Cyclone
sync.