### PR TITLE
Remaining formatting issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: format
+
+format:
+	@find . -name "*.lua" -not -path  "./Libs/*" -exec luaformatter -a -t 1 {} \; 

--- a/Plugins/CustomBar.lua
+++ b/Plugins/CustomBar.lua
@@ -1,4 +1,4 @@
-﻿assert(BigWigs, "BigWigs not found!")
+assert(BigWigs, "BigWigs not found!")
 
 ----------------------------
 --      Localization      --

--- a/Plugins/RaidIcon.lua
+++ b/Plugins/RaidIcon.lua
@@ -1,4 +1,4 @@
-﻿assert(BigWigs, "BigWigs not found!")
+assert(BigWigs, "BigWigs not found!")
 
 ------------------------------
 --      Are you local?      --
@@ -21,11 +21,11 @@ L:RegisterTranslations("enUS", function() return {
 	["Place"] = true,
 	["Place Raid Icons"] = true,
 	["Toggle placing of Raid Icons on players."] = true,
-	
+
 	["Icon"] = true,
 	["Set Icon"] = true,
 	["Set which icon to place on players."] = true,
-	
+
 	["Options for Raid Icons."] = true,
 
 	["star"] = true,
@@ -44,11 +44,11 @@ L:RegisterTranslations("koKR", function() return {
 	["Place"] = "지정",
 	["Place Raid Icons"] = "공격대 아이콘 지정",
 	["Toggle placing of Raid Icons on players."] = "플레이어에 공격대 아이콘 지정 토글",
-	
+
 	["Icon"] = "아이콘",
 	["Set Icon"] = "아이콘 설정",
 	["Set which icon to place on players."] = "플레이어에 아이콘 지정을 위한 설정",
-	
+
 	["Options for Raid Icons."] = "공격대 아이콘에 대한 설정",
 
 	["star"] = "별",
@@ -68,13 +68,13 @@ L:RegisterTranslations("zhCN", function() return {
 	["Place"] = "标记",
 	["Place Raid Icons"] = "标记团队图标",
 	["Toggle placing of Raid Icons on players."] = "切换是否在玩家身上标记团队图标",
-	
+
 	["Icon"] = "图标",
 	["Set Icon"] = "设置图标",
 	["Set which icon to place on players."] = "设置玩家身上标记的图标。",
-	
+
 	["Options for Raid Icons."] = "团队图标设置",
-	
+
 	["star"] = "星星",
 	["circle"] = "圆圈",
 	["diamond"] = "钻石",
@@ -91,13 +91,13 @@ L:RegisterTranslations("zhTW", function() return {
 	["Place"] = "標記",
 	["Place Raid Icons"] = "標記團隊圖示",
 	["Toggle placing of Raid Icons on players."] = "切換是否在玩家身上標記團隊圖示",
-	
+
 	["Icon"] = "圖標",
 	["Set Icon"] = "設置圖示",
 	["Set which icon to place on players."] = "設置玩家身上標記的圖示。",
-	
+
 	["Options for Raid Icons."] = "團隊圖示設置",
-	
+
 	["star"] = "星星",
 	["circle"] = "圓圈",
 	["diamond"] = "方塊",
@@ -118,11 +118,11 @@ L:RegisterTranslations("deDE", function() return {
 	["Place"] = "Platzierung",
 	["Place Raid Icons"] = "Schlachtzug-Symbole platzieren",
 	["Toggle placing of Raid Icons on players."] = "Schlachtzug-Symbole auf Spieler setzen.",
-	
+
 	["Icon"] = "Symbol",
 	["Set Icon"] = "Symbol platzieren",
 	["Set which icon to place on players."] = "W\195\164hle, welches Symbol auf Spieler gesetzt wird.",
-	
+
 	["Options for Raid Icons."] = "Optionen f\195\188r Schlachtzug-Symbole.",
 
 	["star"] = "Stern",
@@ -141,11 +141,11 @@ L:RegisterTranslations("frFR", function() return {
 	["Place"] = "Placement",
 	["Place Raid Icons"] = "Placer les icônes de raid",
 	["Toggle placing of Raid Icons on players."] = "Place ou non les icônes de raid sur les joueurs.",
-	
+
 	["Icon"] = "Icône",
 	["Set Icon"] = "Déterminer l'icône",
 	["Set which icon to place on players."] = "Détermine quelle icône sera placée sur les joueurs.",
-	
+
 	["Options for Raid Icons."] = "Options concernant les icônes de raid.",
 
 	["star"] = "étoile",
@@ -188,7 +188,7 @@ BigWigsRaidIcon.consoleOptions = {
 			name = L["Place Raid Icons"],
 			desc = L["Toggle placing of Raid Icons on players."],
 			get = function() return BigWigsRaidIcon.db.profile.place end,
-			set = function(v) BigWigsRaidIcon.db.profile.place = v end,		
+			set = function(v) BigWigsRaidIcon.db.profile.place = v end,
 		},
 		[L["icon"]] = {
 			type = "text",
@@ -217,7 +217,7 @@ function BigWigsRaidIcon:BigWigs_SetRaidIcon(player, iconnumber)
 		icon = L["skull"]
 	end
 	icon = self.icontonumber[icon]
-	
+
 	for i=1,GetNumRaidMembers() do
 		if UnitName("raid"..i) == player then
 			if not iconnumber then

--- a/Plugins/Tranq.lua
+++ b/Plugins/Tranq.lua
@@ -1,4 +1,4 @@
-﻿
+
 assert(BigWigs, "BigWigs not found!")
 
 ----------------------------

--- a/documentation/bossTemplate.lua
+++ b/documentation/bossTemplate.lua
@@ -14,7 +14,7 @@ L:RegisterTranslations("enUS", function() return {
 	cmd = "Testboss",
 
 	start_trigger = "Let the games begin.",
-	
+
 	berserk_cmd = "berserk",
 	berserk_name = "Berserk",
 	berserk_desc = "Warn for when Testboss goes berserk",
@@ -22,7 +22,7 @@ L:RegisterTranslations("enUS", function() return {
 	berserktrigger = "%s goes into a berserker rage!",
 	berserkannounce = "Berserk - Berserk!",
 	berserksoonwarn = "Berserk Soon - Get Ready!",
-	
+
 	add_name = "Dragon",
 } end )
 
@@ -35,7 +35,7 @@ L:RegisterTranslations("deDE", function() return {
 	berserktrigger = "%s bekommt Berserkerwut!",
 	berserkannounce = "Berserk - Berserk!",
 	berserksoonwarn = "Berserkerwut in Kürze - Bereit machen!",
-	
+
 	add_name = "Drache",
 } end )
 
@@ -79,10 +79,10 @@ local berserkannounced = nil
 --module:RegisterYellEngage(L["start_trigger"])
 
 -- called after module is enabled
-function module:OnEnable()	
+function module:OnEnable()
 	self:RegisterEvent("UNIT_HEALTH")
 	self:RegisterEvent("CHAT_MSG_MONSTER_EMOTE")
-	
+
 	self:ThrottleSync(10, syncName.berserk)
 end
 
@@ -154,31 +154,31 @@ end
 ----------------------------------
 
 function module:Test()
-    local function berserkSoon()
-        self:UNIT_HEALTH(boss)
-    end
-    
-    local function berserk()
-        self:CHAT_MSG_MONSTER_EMOTE(L["berserktrigger"])
-    end
-    local function deactivate()
-        self.core:DisableModule(self:ToString())
-    end
-    
-    BigWigs:Print("BigWigsTestboss Test started")
-    BigWigs:Print("  Berserk Soon Warning after 5s")
-    BigWigs:Print("  Berserk after 10s")
-    
-    -- immitate CheckForEngage
-    self:SendEngageSync()    
-    
-    -- berserk soon warning after 5s
-    self:ScheduleEvent(self:ToString().."Test_berserkSoon", berserkSoon, 5, self)
-    
-    -- berserk after 10s
-    self:ScheduleEvent(self:ToString().."Test_sandblast", berserk, 10, self)
-    
-    -- reset after 15s
-    self:ScheduleEvent(self:ToString().."Test_deactivate", deactivate, 15, self)
-    
+	local function berserkSoon()
+		self:UNIT_HEALTH(boss)
+	end
+
+	local function berserk()
+		self:CHAT_MSG_MONSTER_EMOTE(L["berserktrigger"])
+	end
+	local function deactivate()
+		self.core:DisableModule(self:ToString())
+	end
+
+	BigWigs:Print("BigWigsTestboss Test started")
+	BigWigs:Print("  Berserk Soon Warning after 5s")
+	BigWigs:Print("  Berserk after 10s")
+
+	-- immitate CheckForEngage
+	self:SendEngageSync()
+
+	-- berserk soon warning after 5s
+	self:ScheduleEvent(self:ToString().."Test_berserkSoon", berserkSoon, 5, self)
+
+	-- berserk after 10s
+	self:ScheduleEvent(self:ToString().."Test_sandblast", berserk, 10, self)
+
+	-- reset after 15s
+	self:ScheduleEvent(self:ToString().."Test_deactivate", deactivate, 15, self)
+
 end

--- a/documentation/bossTemplate.lua
+++ b/documentation/bossTemplate.lua
@@ -27,7 +27,7 @@ L:RegisterTranslations("enUS", function() return {
 } end )
 
 L:RegisterTranslations("deDE", function() return {
-	start_trigger = "Lasst die Spiele beginnen."
+	start_trigger = "Lasst die Spiele beginnen.",
 
 	berserk_name = "Berserk",
 	berserk_desc = "Warn for when Testboss goes berserk",


### PR DESCRIPTION
This PR fixes the remaining formatting issues.
In order to have all collaborators use the same formatting, this PR adds a makefile with the 'format' goal, which invokes luaformatter with the desired formatting options. Developers can just use 'make format' to format the project before pushing. Libs/ folder is left untouched.

Also, i've fixed some encoding errors: three files in Plugins folder used BOM. Luaformatter doesnt like that. Since all other files don't have a BOM anyway, i removed those.
Also, a syntax error in the bossTemplate is fixed.